### PR TITLE
Feature/fix-UpdateTicketPath  

### DIFF
--- a/svqk-backend/src/integration-test/java/dev/aulait/svqk/interfaces/issue/IssueClient.java
+++ b/svqk-backend/src/integration-test/java/dev/aulait/svqk/interfaces/issue/IssueClient.java
@@ -1,7 +1,8 @@
 package dev.aulait.svqk.interfaces.issue;
 
 import static dev.aulait.svqk.arch.test.RestAssuredUtils.given;
-import static dev.aulait.svqk.interfaces.issue.IssueController.*;
+import static dev.aulait.svqk.interfaces.issue.IssueController.ISSUES_ID_PATH;
+import static dev.aulait.svqk.interfaces.issue.IssueController.ISSUES_PATH;
 
 import dev.aulait.svqk.arch.test.ConstraintViolationResponseDto;
 
@@ -37,11 +38,11 @@ public class IssueClient {
         .as(IssueDto.class);
   }
 
-  public Integer update(IssueUpdateDto issue) { // <.>
+  public Integer update(IssueUpdateDto issue, int issueId) { // <.>
     return Integer.parseInt(
         given() // <.>
             .body(issue)
-            .put(ISSUES_PATH)
+            .put(ISSUES_PATH + "/" + ISSUES_ID_PATH, issueId)
             .then()
             .statusCode(200)
             .extract()

--- a/svqk-backend/src/integration-test/java/dev/aulait/svqk/interfaces/issue/IssueControllerIT.java
+++ b/svqk-backend/src/integration-test/java/dev/aulait/svqk/interfaces/issue/IssueControllerIT.java
@@ -26,7 +26,8 @@ class IssueControllerIT {
 
     // Update
     createdIssue.setSubject("test subject: " + RandomStringUtils.randomAlphanumeric(5));
-    client.update(IssueUpdateDto.builder().issue(createdIssue).journal(new JournalDto()).build());
+    client.update(
+        IssueUpdateDto.builder().issue(createdIssue).journal(new JournalDto()).build(), issueId);
 
     IssueDto updatedIssue = client.get(issueId);
 

--- a/svqk-backend/src/main/java/dev/aulait/svqk/interfaces/issue/IssueController.java
+++ b/svqk-backend/src/main/java/dev/aulait/svqk/interfaces/issue/IssueController.java
@@ -57,9 +57,7 @@ public class IssueController {
   public int update(@PathParam("issueId") int id, @Valid IssueUpdateDto dto) {
     dto.getIssue().setId(id);
     IssueEntity issue = BeanUtils.map(dto.getIssue(), IssueEntity.class);
-
     JournalEntity journal = BeanUtils.map(dto.getJournal(), JournalEntity.class);
-
     IssueEntity updatedIssue = service.update(issue, journal);
 
     return updatedIssue.getId();

--- a/svqk-backend/src/main/java/dev/aulait/svqk/interfaces/issue/IssueController.java
+++ b/svqk-backend/src/main/java/dev/aulait/svqk/interfaces/issue/IssueController.java
@@ -53,8 +53,11 @@ public class IssueController {
   }
 
   @PUT
-  public int update(@Valid IssueUpdateDto dto) {
+  @Path(ISSUES_ID_PATH)
+  public int update(@PathParam("issueId") int id, @Valid IssueUpdateDto dto) {
+    dto.getIssue().setId(id);
     IssueEntity issue = BeanUtils.map(dto.getIssue(), IssueEntity.class);
+
     JournalEntity journal = BeanUtils.map(dto.getJournal(), JournalEntity.class);
 
     IssueEntity updatedIssue = service.update(issue, journal);

--- a/svqk-backend/src/main/java/dev/aulait/svqk/interfaces/issue/IssueDto.java
+++ b/svqk-backend/src/main/java/dev/aulait/svqk/interfaces/issue/IssueDto.java
@@ -1,5 +1,6 @@
 package dev.aulait.svqk.interfaces.issue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public class IssueDto {
 
   @Schema(required = true, readOnly = true)
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private Integer id;
 
   @Schema(required = true)

--- a/svqk-e2etest/tests/api/Api.ts
+++ b/svqk-e2etest/tests/api/Api.ts
@@ -424,22 +424,6 @@ export class Api<
      * No description
      *
      * @tags Issue Controller
-     * @name IssuesUpdate
-     * @request PUT:/api/issues
-     */
-    issuesUpdate: (data: IssueUpdateModel, params: RequestParams = {}) =>
-      this.request<number, any>({
-        path: `/api/issues`,
-        method: "PUT",
-        body: data,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Issue Controller
      * @name IssuesCreate
      * @request POST:/api/issues
      */
@@ -499,6 +483,26 @@ export class Api<
         path: `/api/issues/${issueId}`,
         method: "GET",
         format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Issue Controller
+     * @name IssuesUpdate
+     * @request PUT:/api/issues/{issueId}
+     */
+    issuesUpdate: (
+      issueId: number,
+      data: IssueUpdateModel,
+      params: RequestParams = {}
+    ) =>
+      this.request<number, any>({
+        path: `/api/issues/${issueId}`,
+        method: "PUT",
+        body: data,
+        type: ContentType.Json,
         ...params,
       }),
 

--- a/svqk-frontend/src/lib/arch/api/Api.ts
+++ b/svqk-frontend/src/lib/arch/api/Api.ts
@@ -424,22 +424,6 @@ export class Api<
      * No description
      *
      * @tags Issue Controller
-     * @name IssuesUpdate
-     * @request PUT:/api/issues
-     */
-    issuesUpdate: (data: IssueUpdateModel, params: RequestParams = {}) =>
-      this.request<number, any>({
-        path: `/api/issues`,
-        method: "PUT",
-        body: data,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags Issue Controller
      * @name IssuesCreate
      * @request POST:/api/issues
      */
@@ -499,6 +483,26 @@ export class Api<
         path: `/api/issues/${issueId}`,
         method: "GET",
         format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Issue Controller
+     * @name IssuesUpdate
+     * @request PUT:/api/issues/{issueId}
+     */
+    issuesUpdate: (
+      issueId: number,
+      data: IssueUpdateModel,
+      params: RequestParams = {}
+    ) =>
+      this.request<number, any>({
+        path: `/api/issues/${issueId}`,
+        method: "PUT",
+        body: data,
+        type: ContentType.Json,
         ...params,
       }),
 

--- a/svqk-frontend/src/lib/domain/issue/IssueForm.svelte
+++ b/svqk-frontend/src/lib/domain/issue/IssueForm.svelte
@@ -29,7 +29,9 @@
 
   async function save() {
     const response = await ApiHandler.handle<number>(fetch, (api) =>
-      issue.id ? api.issues.issuesUpdate({ issue, journal }) : api.issues.issuesCreate(issue)
+      issue.id
+        ? api.issues.issuesUpdate(issue.id, { issue, journal })
+        : api.issues.issuesCreate(issue)
     );
 
     if (response) {
@@ -40,7 +42,9 @@
   }
 
   async function deleteIssue() {
-    const response = await ApiHandler.handle<number>(fetch, (api) => api.issues.issuesDelete(issue.id, issue));
+    const response = await ApiHandler.handle<number>(fetch, (api) =>
+      api.issues.issuesDelete(issue.id, issue)
+    );
 
     if (response) {
       await handleAfterDelete();


### PR DESCRIPTION
▫️変更概要
[svqk] チケット更新APIのパス修正

▫️変更内容
- パスを/api/issues/{issueId}とする
- IssueDto.idに@JsonProperty(access = JsonProperty.Access.READ_ONLY)を設定する
  - 更新時はパスパラメーターとして取得したものを当該フィールドに設定する

▫️関連チケット
http://sitoolkit-dev.monocrea.co.jp/redmine/issues/14238